### PR TITLE
issues #87 & #86  – Returns the correct lessons_count for the 3 and 6 months 

### DIFF
--- a/src/db_queries/admin_partners_mentors.ts
+++ b/src/db_queries/admin_partners_mentors.ts
@@ -101,7 +101,7 @@ export class AdminPartnersMentors {
         ),
         mentor_courses_lessons AS
         (
-          SELECT ucm.mentor_id, sum(round(ct.duration*30.0/7)) AS lessons_count
+          SELECT ucm.mentor_id, sum(round((ct.duration*30)/7) + (ct.duration)/3 + 1) AS lessons_count
           FROM users_courses_mentors ucm
           INNER JOIN users_courses uc ON uc.id = ucm.course_id
           INNER JOIN course_types ct ON ct.id = uc.course_type_id


### PR DESCRIPTION
https://github.com/MentorsWithoutBorders/mwb-partners-admin/issues/87
https://github.com/MentorsWithoutBorders/mwb-partners-admin/issues/86

When I call the endpoint `/api/v1/partners/aac344ee-6cdf-4acd-8e60-609bfbc589b7/mentors` 

now for duration 6:
<img width="911" alt="image" src="https://github.com/MentorsWithoutBorders/mwb-connect-backend/assets/4181674/65ac6748-5667-4c14-beda-2289d34d34d5">

And for duration 3: 
<img width="790" alt="image" src="https://github.com/MentorsWithoutBorders/mwb-connect-backend/assets/4181674/5f88988e-f812-455b-b8ad-ac2dc8271af5">
